### PR TITLE
Autoload functions.php File (#10)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,10 @@
     "autoload": {
         "psr-4": {
             "EricMakesStuff\\ServerMonitor\\": "src/"
-        }
+        },
+        "files": [
+            "src/Helpers/functions.php"
+        ]
     },
     "require": {
         "illuminate/support": "^5.1",

--- a/src/Helpers/functions.php
+++ b/src/Helpers/functions.php
@@ -5,7 +5,7 @@ use EricMakesStuff\ServerMonitor\Helpers\ConsoleOutput;
 /**
  * @return \EricMakesStuff\ServerMonitor\Helpers\ConsoleOutput
  */
-function consoleOutput()
+function monitorConsoleOutput()
 {
     return app(ConsoleOutput::class);
 }

--- a/src/Notifications/Notifier.php
+++ b/src/Notifications/Notifier.php
@@ -156,7 +156,7 @@ class Notifier
                         .$exception->getTraceAsString();
 
                     $this->log->error($errorMessage);
-                    consoleOutput()->error($errorMessage);
+                    monitorConsoleOutput()->error($errorMessage);
                 }
             });
     }


### PR DESCRIPTION
- Autoload functions.php file for consoleOutput() command
- Rename consoleOutput function to avoid collisions
